### PR TITLE
removed 'docs/' from 'firefox-esr docs/_build/html/index.html'

### DIFF
--- a/docs/software_dev/documentation.rst
+++ b/docs/software_dev/documentation.rst
@@ -55,4 +55,4 @@ After executing the above commands, you should have a new ``docs/_build/html/`` 
 
 ::
 
-  firefox-esr docs/_build/html/index.html
+  firefox-esr _build/html/index.html


### PR DESCRIPTION
removed docs/ because you're already in the docs directory when you run the command. 