### PR TITLE
Move GPL copyright statement to the README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Cross Platform Python GUI
-    Copyright (C) 2020  Michael Altfield
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Cross Platform Python GUI  Copyright (C) 2020  Michael Altfield
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,22 @@ To contact us via email, please visit:
 
 # License
 
-The contents of this repo are dual-licensed. All code is GPLv3 and all other content is CC-BY-SA.
+Copyright (C) 2020-2022 Michael Altfield
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+All code is GPLv3 and all other content is CC-BY-SA.
 
 # For more Information
 


### PR DESCRIPTION
I noticed that the copy of the GPL has been modified. There are two problems with this:

- it's in the section that is designed for other people to copy paste into their code (so they could accidentally end up with Michael Altfield in their programs
- the FSF doesn't allow modification of the license text unless the name of the license is changed too

The right place to put that copyright statement is somewhere like the README. Not sure whether that's exactly how you want it, but here's a suggestion of how to do it.