### PR TITLE
Clarify code and non-code license

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ To contact us via email, please visit:
 
 Copyright (C) 2020-2022 Michael Altfield and the BusKill Team
 
-The contents of this repo are dual-licensed. All code is GPLv3 and all other content is CC-BY-SA.
+The contents of this repo are under the GPL version 3 or later.
+In addition, any content other than code can also be used, at your
+choice, under CC-BY-SA version 4.0.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Here's a further set of suggestions for the license statement. It addresses two practical problems:

1. While CC-BY-SA 4.0 is compatible with GPLv3, it may interfere with the Buskill project's ability to upgrade to GPLv4 in the future if that license becomes available and the project wants to upgrade. See https://www.gnu.org/licenses/license-list.en.html#ccbysa for an explanation.
2. I need to list what files are under what license before uploading buskill to Debian and that's tedious because there are a lot of non-code files. Having all of the non-code files license under "your choice of GPLv3 or CC-BY-SA 4" means I can simply list the whole thing as GPLv3 for Debian.

The PR also makes the version numbers more explicit. CC-BY-SA 4.0 is the only one that's GPLv3-compatible.