### PR TITLE
fix nav drawer gesture on all screens (#43)

### DIFF
--- a/src/buskill.kv
+++ b/src/buskill.kv
@@ -7,7 +7,7 @@
 # Updated: 2023-06-14
 # Version: 0.3
 ################################################################################
-
+#:import BusKillNavigationDrawer buskill_gui
 
 <CriticalError>:
 
@@ -64,7 +64,7 @@
 					title: '[font=RobotoMedium][size=20]   BusKill[/size][/font]'
 					on_release: root.toggle_menu()
 
-		NavigationDrawer:
+		BusKillNavigationDrawer:
 			id: nav_drawer
 			anim_type: 'slide_above_simple'
 			side_panel_width: min( dp(300), 0.8*self.width )

--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -89,6 +89,41 @@ def get_screen_manager(obj):
 
 	return None
 
+class BusKillNavigationDrawer(NavigationDrawer):
+    """Fixes issue #43: nav drawer swipe gesture works on all screens.
+
+    Root cause: Kivy dispatches on_touch_down to children first. Child
+    screens (Settings, DebugLog, etc.) consume the touch before the
+    NavigationDrawer can detect the left-edge swipe gesture.
+
+    Fix: grab left-edge touches before dispatching to children.
+    """
+
+    def on_touch_down(self, touch):
+        if not self.collide_point(*touch.pos):
+            return super().on_touch_down(touch)
+
+        if self._anim_progress < 0.001:
+            if touch.x <= self.touch_accept_width:
+                self._touch = touch
+                touch.grab(self)
+                self._start_touch_x = touch.x
+                self._start_time = touch.time_start
+                super().on_touch_down(touch)
+                return True
+
+        return super().on_touch_down(touch)
+
+    def on_touch_move(self, touch):
+        if touch.grab_current is self:
+            return super().on_touch_move(touch)
+        return super().on_touch_move(touch)
+
+    def on_touch_up(self, touch):
+        if touch.grab_current is self:
+            return super().on_touch_up(touch)
+        return super().on_touch_up(touch)
+
 class MainWindow(Screen):
 
 	toggle_btn = ObjectProperty(None)

--- a/src/packages/garden/navigationdrawer/__init__.py
+++ b/src/packages/garden/navigationdrawer/__init__.py
@@ -515,7 +515,8 @@ class NavigationDrawer(StencilView):
                             touch.x <=
                             (self.x + self.touch_accept_width))
             if not valid_region:
-                self._main_panel.on_touch_down(touch)
+                if col_main:
+                    self._main_panel.on_touch_down(touch)
                 return False
         else:
             if col_side and not self._main_above:


### PR DESCRIPTION
## What this PR does

Fixes the navigation drawer swipe gesture so it works on all screens (Settings, About, Debug Log), not just the home screen. Closes #43.

## Why

When the drawer is closed, `NavigationDrawer.on_touch_down` calls `self._main_panel.on_touch_down(touch)` directly for any touch outside the left-edge zone. On child screens like Settings and Debug Log, the main panel's widgets consume the touch and return `True`, so the drawer gesture never gets a chance to grab it. The home screen happened to work because its layout left the left edge uncovered.

## How

Three changes:

- Added `BusKillNavigationDrawer` subclass in `src/buskill_gui.py` that overrides `on_touch_down` to grab left-edge touches before dispatching to children
- Updated `src/buskill.kv` to use `BusKillNavigationDrawer` instead of `NavigationDrawer`
- Fixed `on_touch_down` in `src/packages/garden/navigationdrawer/__init__.py` to guard `_main_panel` touch dispatch with a `col_main` check

## Testing

Tested swipe gesture on:
- [x] Home screen (was already working)
- [x] Settings screen (was broken, now fixed)
- [x] About screen (was broken, now fixed)
- [x] Debug Log screen (was broken, now fixed)

Tested on: Linux (Ubuntu 24.04), Kivy 2.3.1

Untested on: macOS, Windows