### PR TITLE
Fix incorrect exit code for --list-triggers

### DIFF
--- a/src/buskill_cli.py
+++ b/src/buskill_cli.py
@@ -146,7 +146,7 @@ def BusKillCLI( buskill_object ):
 		print( "Supported triggers include:" )
 		for trigger in bk.SUPPORTED_TRIGGERS:
 			print( "\t" +str(trigger))
-		sys.exit(1)
+		sys.exit(0)
 
 	# did the user ask us to do a software upgrade?
 	if args.upgrade:


### PR DESCRIPTION
## Description
Fixes #116 
Changed Exit Code For --list-triggers from 1 to 0 .

The command successfully  lists available Triggers, so it should be return  a success exit  status instead of an error status.