### PR TITLE
Add persistent log

### DIFF
--- a/src/buskill_cli.py
+++ b/src/buskill_cli.py
@@ -111,13 +111,6 @@ def BusKillCLI( buskill_object ):
 	 action="store_true"
 	)
 
-	# These arguments do not play a major role other than showing its use case 
-	# Can initialise the persistent debug from here using the stack-overflow reference https://stackoverflow.com/questions/6255050/python-thinking-of-a-module-and-its-variables-as-a-singleton-clean-approach
-	parser.add_argument(
-	 "-d","--debug",
-	 help="To initiate persistent log"
-	)
-
 	# process command-line arguments
 	args = parser.parse_args()
 

--- a/src/buskill_cli.py
+++ b/src/buskill_cli.py
@@ -111,6 +111,13 @@ def BusKillCLI( buskill_object ):
 	 action="store_true"
 	)
 
+	# These arguments do not play a major role other than showing its use case 
+	# Can initialise the persistent debug from here using the stack-overflow reference https://stackoverflow.com/questions/6255050/python-thinking-of-a-module-and-its-variables-as-a-singleton-clean-approach
+	parser.add_argument(
+	 "-d","--debug",
+	 help="To initiate persistent log"
+	)
+
 	# process command-line arguments
 	args = parser.parse_args()
 

--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 	global bk
 	bk = packages.buskill.BusKill()
 
-	if bk.persistent_log:
+	if bk.PERSISTENT_LOG:
 		# Initialising new location for the log file
 		log_file_path = os.path.join( bk.DATA_DIR , 'buskill.log')
 		start_logging(log_file_path)

--- a/src/main.py
+++ b/src/main.py
@@ -74,11 +74,7 @@ if __name__ == '__main__':
 	global bk
 	bk = packages.buskill.BusKill()
 
-	# sys argument fr persistent log
-	# Can be moved to buskill_cli using reference from https://stackoverflow.com/questions/6255050/python-thinking-of-a-module-and-its-variables-as-a-singleton-clean-approach 
-	persistent_debug = '--debug' in sys.argv 
-
-	if persistent_debug:
+	if bk.persistent_log:
 		# Initialising new location for the log file
 		log_file_path = os.path.join( bk.DATA_DIR , 'buskill.log')
 		start_logging(log_file_path)

--- a/src/main.py
+++ b/src/main.py
@@ -74,20 +74,18 @@ if __name__ == '__main__':
 	global bk
 	bk = packages.buskill.BusKill()
 
-	if bk.PERSISTENT_LOG:
-		# Initialising new location for the log file
-		log_file_path = os.path.join( bk.DATA_DIR , 'buskill.log')
+	# Decision whether to write to DATA_DIR or TEMP file 
+	log_dir = bk.DATA_DIR if bk.PERSISTENT_LOG else tempfile.gettempdir()
+
+	try: 
+		log_file_path = os.path.join( log_dir , 'buskill.log' )
 		start_logging(log_file_path)
-	else:	
-		try: 
-			log_file_path = os.path.join( tempfile.gettempdir() , 'buskill.log' )
-			start_logging(log_file_path)
-		except PermissionError:
-			# adding a fallback log to avoid PermissionError
-			# This creates a new file that appends the timestamp to the log file
-			timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-			log_file_path = os.path.join( tempfile.gettempdir() , f'buskill.{timestamp}.log')
-			start_logging(log_file_path)
+	except PermissionError:
+		# adding a fallback log to avoid PermissionError
+		# This creates a new file that appends the timestamp to the log file
+		timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+		log_file_path = os.path.join( log_dir , f'buskill.{timestamp}.log')
+		start_logging(log_file_path)
 	
 	bk.LOG_FILE_PATH = log_file_path
 

--- a/src/main.py
+++ b/src/main.py
@@ -68,17 +68,32 @@ if __name__ == '__main__':
 
 	# TODO: disable logging by default; enable it with an argument
 	# TODO: be able to override the path to the log file with an env var or argument value; make these just the defaults
+	
+	# instantiate the buskill object EARLY
+	# Moved to top so that DATA_DIR path can be found from the buskill class
+	global bk
+	bk = packages.buskill.BusKill()
 
-	try: 
-		log_file_path = os.path.join( tempfile.gettempdir() , 'buskill.log' )
+	# sys argument fr persistent log
+	# Can be moved to buskill_cli using reference from https://stackoverflow.com/questions/6255050/python-thinking-of-a-module-and-its-variables-as-a-singleton-clean-approach 
+	persistent_debug = '--debug' in sys.argv 
+
+	if persistent_debug:
+		# Initialising new location for the log file
+		log_file_path = os.path.join( bk.DATA_DIR , 'buskill.log')
 		start_logging(log_file_path)
-	except PermissionError:
-		# adding a fallback log to avoid PermissionError
-		# This creates a new file that appends the timestamp to the log file
-		timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-		log_file_path = os.path.join( tempfile.gettempdir() , f'buskill.{timestamp}.log')
-		
-		start_logging(log_file_path)
+	else:	
+		try: 
+			log_file_path = os.path.join( tempfile.gettempdir() , 'buskill.log' )
+			start_logging(log_file_path)
+		except PermissionError:
+			# adding a fallback log to avoid PermissionError
+			# This creates a new file that appends the timestamp to the log file
+			timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+			log_file_path = os.path.join( tempfile.gettempdir() , f'buskill.{timestamp}.log')
+			start_logging(log_file_path)
+	
+	bk.LOG_FILE_PATH = log_file_path
 
 	msg = "==============================================================================="
 	print( msg ); logging.info( msg )
@@ -152,10 +167,6 @@ if __name__ == '__main__':
 
 	msg = "buskill version " +str(BUSKILL_VERSION)
 	print( msg ); logging.info( msg )
-
-	# instantiate the buskill object
-	global bk
-	bk = packages.buskill.BusKill()
 
 	#############
 	# LAUNCH UI #

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -227,7 +227,7 @@ class BusKill:
 
 		# BusKill class was always initialised after finding the log file path Therefore in the new setup we are initialising it before the log file path is found
 		# This will prevent it from out of index error 
-		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else Non
+		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else None
 		
 		self.EXE_PATH = None
 		self.EXE_DIR = None

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -224,7 +224,11 @@ class BusKill:
 		self.SIMULATE_HOTPLUG_REMOVAL = False
 
 		self.EXECUTED_AS_SCRIPT = None
-		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename
+
+		# BusKill class was always initialised after finding the log file path Therefore in the new setup we are initialising it before the log file path is found
+		# This will prevent it from out of index error 
+		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else Non
+		
 		self.EXE_PATH = None
 		self.EXE_DIR = None
 		self.EXE_FILE = None

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -228,6 +228,8 @@ class BusKill:
 		# BusKill class was always initialised after finding the log file path Therefore in the new setup we are initialising it before the log file path is found
 		# This will prevent it from out of index error 
 		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else None
+		# Default value as False, because if no one updates the config.ini file then reverting back to old file path
+		self.persistent_log = False
 		
 		self.EXE_PATH = None
 		self.EXE_DIR = None
@@ -433,6 +435,8 @@ class BusKill:
 		msg = "DEBUG: CONF_FILE:|" +str(self.CONF_FILE)+  "|\n"
 		print( msg ); logger.debug( msg )
 
+		# running the config option only after the implimentation of the config file
+		self.getConfigOption()
 
 		# handle conditions where this version was already upgraded by a newer
 		# version or if this is a version that upgraded an older version
@@ -445,6 +449,20 @@ class BusKill:
 	#  * https://bugs.python.org/issue34034
 	#  * https://docs.python.org/3/library/pickle.html#object.__reduce__
 	#  * https://docs.python.org/3/library/pickle.html#object.__getstate__
+	
+
+	# Old config file reading option only exist after the toggling between the arm and disarm functionality
+	# Created a new function to get config option for persistent log file
+	def getConfigOption(self):
+		self.config = configparser.ConfigParser()
+		self.config.read( self.CONF_FILE )
+
+		if self.config.has_option('buskill', 'persistent_log'):
+			self.persistent_log = self.config.getboolean(
+				'buskill',
+				'persistent_log'
+			)
+	
 	def __getstate__(self):
 
 		state = self.__dict__.copy()

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -229,7 +229,7 @@ class BusKill:
 		# This will prevent it from out of index error 
 		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else None
 		# Default value as False, because if no one updates the config.ini file then reverting back to old file path
-		self.persistent_log = False
+		self.PERSISTENT_LOG = False
 		
 		self.EXE_PATH = None
 		self.EXE_DIR = None
@@ -458,7 +458,7 @@ class BusKill:
 		self.config.read( self.CONF_FILE )
 
 		if self.config.has_option('buskill', 'persistent_log'):
-			self.persistent_log = self.config.getboolean(
+			self.PERSISTENT_LOG = self.config.getboolean(
 				'buskill',
 				'persistent_log'
 			)


### PR DESCRIPTION
# Persistent Logging
I have implemented the persistent logging feature in CLI, I have not integrated it in GUI, The idea is simple if the user have given a debug flag in the terminal then instead of the program writing the log to /tmp/buskill.log, it will write to DATA_DIR/buskill.log.
The CLI work around of getting the bool is a bit clumsy but I have also added a reference link from stack-overflow, If you wanted I can implement that instead of the present implementation style 

# Problems faced
There was quite a lot of challenges That I have faced, And some was quite hilarious as I was trying to solve the problem which I had already solved earlier but still was trying to wrap my brain around it 

- Logging was initialized before BusKill() instantiation The biggest issue was that logging initialization happens very early in main.py, before the BusKill object is instantiated. This created an architectural issue because, DATA_DIR only becomes available after BusKill() initialization, but the logging path must be decided before logging initialization, This prevented directly using bk.DATA_DIR during initial log setup.
- logger.root.handlers[0] indexing issue; Inside BusKill.__init__, the following line caused an indexing error if logging had not already been initialized **self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename** This meant:
     - The class depended on logging already existing
     - but persistent logging required information from the class before logging setup
     
  This circular dependency was the main source of the implementation difficulty.
  This was Issue I was taking earlier :sob: 
- Initially I introduced **self.persistent_log = False** inside BusKill.__init__. Then inside buskill_cli.py **buskill_object.persistent_log = args.debug** However, the value appeared unchanged in main.py. After debugging with id() checks, I discovered; different BusKill() instances were being referenced logging initialization occurred before CLI argument processing, So the --debug argument was being applied too late to influence the initial log path.

# Conclusion
I checked the working across root and regular user and it is working as intended 
The path to DATA_DIR in my case is the <user_dir>/.local/share/.buskill/buskill.log across both root and regular user 
If any problem or implementation logic flaw exist please let me know and I will also give you the reference link to the stack-overflow solution that I was referring down below 
[stack_overflow_solution](https://stackoverflow.com/questions/6255050/python-thinking-of-a-module-and-its-variables-as-a-singleton-clean-approach)

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Sincerely,
Raihan :nerd_face:   