### PR TITLE
fix: schedule RecycleView data update on main thread in show_debug_log

### DIFF
--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -1029,7 +1029,7 @@ class DebugLog(Screen):
 		lines = []
 		for line in self.debug_log_contents.splitlines(keepends=False):
 			lines.append({'text': line})
-		self.rv.data = lines
+		Clock.schedule_once(lambda dt: setattr(self.rv, 'data', lines), 0)
 
 	def copy_debug_log( self ):
 


### PR DESCRIPTION
## Description

\show_debug_log()\ runs inside a \	hreading.Thread\ but was directly mutating \self.rv.data\ (a Kivy \RecycleView\ property), which is not thread-safe. Kivy UI properties must only be modified from the main thread.

## Fix

Wrapped the \self.rv.data\ assignment in \Clock.schedule_once\ so it executes on the main thread on the next frame. \Clock\ was already imported at the top of the file.

## Testing

The thread builds the \lines\ list, schedules the callback, and exits. The \DebugLog\ screen is kept alive by the screen manager, so \self\ won't be GC'd before the callback fires.

Related issue: #114