### PR TITLE
fix: break circular layout dependency causing RecycleView infinite loop (fixes #124)

### DIFF
--- a/src/buskill.kv
+++ b/src/buskill.kv
@@ -343,28 +343,13 @@
 #					size: self.size
 
 <BusKillOptionItem>:
-	size_hint: .25, None
+	size_hint: 1, None
 	height: labellayout.height + dp(10)
 	padding: 6
 	spacing: 5
 
 	icon_label: icon_label
 	radio_button_label: radio_button_label
-
-# uncomment to debug boundaries
-#	canvas:
-#		Color:
-#			#rgba: 47 / 255., 167 / 255., 212 / 255., self.selected_alpha
-#			#rgba: 0, 1, 0, 1
-#			rgba: (0, 1, 0, 1 if DEBUG == True else 0, 0, 0, 0)
-#		Rectangle:
-#			pos: self.x, self.y + 1
-#			size: self.size
-#		Color:
-#			rgb: .2, .2, .2
-#		Rectangle:
-#			pos: self.x, self.y - 2
-#			size: self.width, 1
 
 	StackLayout:
 		pos: root.pos
@@ -375,21 +360,9 @@
 		Label:
 			id: radio_button_label
 			markup: True
-			#text: ('[font=mdicons][size=18sp]\ue837[/size][/font] ' if root.parent_option.value == root.value else '[font=mdicons][size=18sp]\ue836[/size][/font] ')
-			#text: '[font=mdicons][size=18sp]\ue837[/size][/font] '
 			text: root.radio_button_icon
 			size: self.texture_size
 			size_hint: None, None
-			height: labellayout.height
-			#height: dp(300)
-
-# uncomment to debug boundaries
-#			canvas.before:
-#				Color:
-#					rgba: 1, 0, 0, 1
-#				Rectangle:
-#					pos: self.pos
-#					size: self.size
 
 		Label:
 			id: icon_label
@@ -397,30 +370,17 @@
 			text: ('[font=mdicons][size=40sp][color=ffffff00]\ue256[/color][/size][/font]' if root.icon == None else '[font=mdicons][size=40sp]' +root.icon+ '[/size][/font]')
 			size: self.texture_size
 			size_hint: None, None
-			height: labellayout.height
-			#height: dp(300)
-
-# uncomment to debug boundaries
-#			canvas.before:
-#				Color:
-#					rgba: 0, 0, 1, 1
-#				Rectangle:
-#					pos: self.pos
-#					size: self.size
 
 		Label:
 			id: labellayout
 			markup: True
 			text: u'{0}\n[size=13sp][color=999999]{1}[/color][/size]'.format(root.option_human or root.value or '', root.desc or '')
 			font_size: '15sp'
-			text_size: root.width - icon_label.width - radio_button_label.width - (2*root.padding) - (2*root.spacing), None
+			text_size: root.width - dp(100), None
 			size: self.texture_size
 			size_hint: None, None
 
-			# set the minimum height of this item so that fat fingers don't have
-			# issues on small touchscreen displays (for better UX)
 			height: max(self.height, dp(80))
-			#height: dp(1000)
 
 # uncomment to debug boundaries
 #			canvas.before:

--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -916,9 +916,8 @@ class ComplexOptionsScreen(Screen):
 				# set the radio button icon to "unselected"
 				self.rv.data[n]['radio_button_icon'] = '[font=mdicons][size=18sp]\ue836[/size][/font] '
 
-		# update RecycleView data in next frame
-		# * https://stackoverflow.com/questions/49935190/kivy-how-to-initialize-the-viewclass-of-the-recycleview-dynamically
-		Clock.schedule_once(self.rv.refresh_from_data,0)
+		# trigger RecycleView refresh by replacing data list
+		self.rv.data = list(self.rv.data)
 
 # This is our main Screen when the user clicks "Settings" in the nav drawer
 class BusKillSettingsScreen(Screen):


### PR DESCRIPTION
## Summary

Fixes #124 - RecycleView infinite layout loop when changing font settings.

## Root Cause

The BusKillOptionItem had a circular sizing dependency in buskill.kv:

- BusKillOptionItem.height = labellayout.height + dp(10)
- radio_button_label.height = labellayout.height
- icon_label.height = labellayout.height
- labellayout.text_size[0] = root.width - icon_label.width - radio_button_label.width

When a font setting changes:
1. Icon/radio label texture size changes -> widths change
2. labellayout.text_size changes -> text re-wraps -> height changes
3. BusKillOptionItem.height changes -> grid re-layouts
4. Kivy resizes children -> widths change again -> infinite loop

## Changes

### src/buskill.kv
- Fixed size_hint from .25, None to 1, None
- Removed height: labellayout.height from radio/icon labels
- Changed text_size to fixed root.width - dp(100)

### src/buskill_gui.py
- Replaced Clock.schedule_once(self.rv.refresh_from_data, 0) with self.rv.data = list(self.rv.data) for deterministic single-pass refresh