### PR TITLE
GUI Toggle option and Adding config option

### DIFF
--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -1416,10 +1416,7 @@ class BusKillApp(App):
 		importlib.reload( kivy.config )
 
 		Config.read( self.bk.CONF_FILE )
-		Config.setdefaults('buskill', {
-		 'buskill_trigger': 'lock-screen',
-		 'persistent_log': 'False'
-		})	
+		Config.setdefaults('buskill', self.bk.DEFAULT_CONF) # For more future only have to update the DEFAULT_CONF value in __init__.py
 
 		# TODO: don't hard-code this, pull it from kivy/config.py
 		# * https://stackoverflow.com/questions/78216476/how-to-get-kivy-to-set-its-defaults-in-the-config-at-runtime

--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -1416,7 +1416,7 @@ class BusKillApp(App):
 		importlib.reload( kivy.config )
 
 		Config.read( self.bk.CONF_FILE )
-		Config.setdefaults('buskill', self.bk.DEFAULT_CONF) # For more future only have to update the DEFAULT_CONF value in __init__.py
+		Config.setdefaults('buskill', self.bk.DEFAULT_CONF) # For more config option in future, only have to update the DEFAULT_CONF value in __init__.py
 
 		# TODO: don't hard-code this, pull it from kivy/config.py
 		# * https://stackoverflow.com/questions/78216476/how-to-get-kivy-to-set-its-defaults-in-the-config-at-runtime

--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -1418,6 +1418,7 @@ class BusKillApp(App):
 		Config.read( self.bk.CONF_FILE )
 		Config.setdefaults('buskill', {
 		 'buskill_trigger': 'lock-screen',
+		 'persistent_log': 'False'
 		})	
 
 		# TODO: don't hard-code this, pull it from kivy/config.py

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -427,7 +427,7 @@ class BusKill:
 			# top to make UX *slightly* better for a user who wants to manually
 			# edit the config file. if we don't do this, then kivy will put it
 			# below its own settings, making the user scroll a lot to find them
-			contents = "[buskill]\n"
+			contents = "[buskill]\npersistent_log = False\n" # Updating the config option
 			with open( self.CONF_FILE, 'w' ) as fd:
 				fd.write( contents )
 

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -419,6 +419,12 @@ class BusKill:
 		# path to buskill's config file
 		self.CONF_FILE = os.path.join( self.DATA_DIR, "config.ini" )
 
+		# Setting up universal default value for both GUI and CLI config options
+		self.DEFAULT_CONF = {
+		 'buskill_trigger': 'lock-screen',
+		 'persistent_log': self.PERSISTENT_LOG
+		}
+
 		# does the config file exist already?
 		if not os.path.exists( self.CONF_FILE ):
 			# the config file doesn't exist yet; create it
@@ -427,9 +433,19 @@ class BusKill:
 			# top to make UX *slightly* better for a user who wants to manually
 			# edit the config file. if we don't do this, then kivy will put it
 			# below its own settings, making the user scroll a lot to find them
-			contents = "[buskill]\npersistent_log = False\n" # Updating the config option
+			contents = "[buskill]\n"
 			with open( self.CONF_FILE, 'w' ) as fd:
 				fd.write( contents )
+
+			# For CLI and GUI config option Initialising it when the config.ini file is created 
+			# So when ever any new config option is to be added only have to add it to self.DEFAULT_CONF dict
+			# This will only run once when user either runs CLI or GUI
+			# The users who run the CLI can change the file manually and still the user change persist 
+			config = configparser.ConfigParser()
+			config.read( self.CONF_FILE )
+			config['buskill'] = self.DEFAULT_CONF
+			with open(self.CONF_FILE, 'w') as fd:
+				config.write(fd)
 
 		msg = "DEBUG: CACHE_DIR:|" +str(self.CACHE_DIR)+  "|\n"
 		msg = "DEBUG: CONF_FILE:|" +str(self.CONF_FILE)+  "|\n"

--- a/src/packages/buskill/settings_buskill.json
+++ b/src/packages/buskill/settings_buskill.json
@@ -14,6 +14,23 @@
 	},
 	{
 		"type": "title",
+		"title": "Buskill Complex Settings Option"
+	},
+	{
+		"icon": "",
+		"type": "complex-options",
+		"title": "Persistent Logging",
+		"desc": "DO you want to store the log ?",
+		"section": "buskill",
+		"key": "persistent_log",
+		"options": ["True","False"],
+		"options_human": ["True","False"],
+		"options_long": ["Log file will be not deleted after your system restarts","Log file will be deleted once you restart the computer"],
+		"confirmation": ["Please restart the app so the changes can be implimented","Please restart the app so the changes can be implimented"],
+		"options_icons": ["",""]
+	},
+	{
+		"type": "title",
 		"title": "Look & Feel"
 	},
 	{

--- a/src/packages/buskill/settings_buskill.json
+++ b/src/packages/buskill/settings_buskill.json
@@ -13,11 +13,7 @@
 		"options_icons": ["\ue1bf","\ue62a"]
 	},
 	{
-		"type": "title",
-		"title": "Buskill Complex Settings Option"
-	},
-	{
-		"icon": "",
+		"icon": "\ue873",
 		"type": "complex-options",
 		"title": "Persistent Logging",
 		"desc": "DO you want to store the log ?",
@@ -27,7 +23,7 @@
 		"options_human": ["True","False"],
 		"options_long": ["Log file will be not deleted after your system restarts","Log file will be deleted once you restart the computer"],
 		"confirmation": ["Please restart the app so the changes can be implimented","Please restart the app so the changes can be implimented"],
-		"options_icons": ["",""]
+		"options_icons": ["\ue161","\ue5cd"]
 	},
 	{
 		"type": "title",

--- a/src/packages/buskill/settings_buskill.json
+++ b/src/packages/buskill/settings_buskill.json
@@ -16,7 +16,7 @@
 		"icon": "\ue873",
 		"type": "complex-options",
 		"title": "Persistent Logging",
-		"desc": "DO you want to store the log ?",
+		"desc": "Do you want to store the log file persistently (keeping the data after your computer reboots)?",
 		"section": "buskill",
 		"key": "persistent_log",
 		"options": ["True","False"],


### PR DESCRIPTION
# 1) Adding persistent log variable to the config file ( easier user understanding )
I have made the small change of adding the config option persistent log to config.ini 
The implementation is using just string concatenation in line 

`contents = "[buskill]\npersistent_log = False\n" # Updating the config option`

As I didn't find any existing architecture that writes to the config file. This works for both GUI and CLI
In the past when we run CLI only 

`[buskill]`

option will be available ( The rest of the config was actually of kivy )
I hope this implementation is fine

# 2) GUI toggle option in setting 
I have a question about the expected behavior.

Since logging is initialized very early in main.py before the GUI is launched, should changing the persistent_log setting in the GUI only affect future launches of BusKill?

Or would you like the logging destination to be reconfigured immediately when the user toggles the option in Settings? ( Which I think will be really hard to implement ) 

[ Same Question ](https://github.com/BusKill/buskill-app/issues/128#issuecomment-4646359556)