### PR TITLE
Fix pytest logging

### DIFF
--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -1418,6 +1418,7 @@ class BusKillApp(App):
 		Config.read( self.bk.CONF_FILE )
 		Config.setdefaults('buskill', {
 		 'buskill_trigger': 'lock-screen',
+		 'persistent_log': 'False'
 		})	
 
 		# TODO: don't hard-code this, pull it from kivy/config.py

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -427,7 +427,7 @@ class BusKill:
 			# top to make UX *slightly* better for a user who wants to manually
 			# edit the config file. if we don't do this, then kivy will put it
 			# below its own settings, making the user scroll a lot to find them
-			contents = "[buskill]\n"
+			contents = "[buskill]\npersistent_log = False\n" # Updating the config option
 			with open( self.CONF_FILE, 'w' ) as fd:
 				fd.write( contents )
 

--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -227,7 +227,8 @@ class BusKill:
 
 		# BusKill class was always initialised after finding the log file path Therefore in the new setup we are initialising it before the log file path is found
 		# This will prevent it from out of index error 
-		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else None
+		handler = logger.root.handlers[0] if logger.root.handlers else None
+		self.LOG_FILE_PATH = getattr(handler, "baseFilename", None) if handler else None # Handle logging handlers without baseFilename 
 		# Default value as False, because if no one updates the config.ini file then reverting back to old file path
 		self.PERSISTENT_LOG = False
 		

--- a/src/packages/buskill/settings_buskill.json
+++ b/src/packages/buskill/settings_buskill.json
@@ -14,6 +14,23 @@
 	},
 	{
 		"type": "title",
+		"title": "Buskill Complex Settings Option"
+	},
+	{
+		"icon": "",
+		"type": "complex-options",
+		"title": "Persistent Logging",
+		"desc": "DO you want to store the log ?",
+		"section": "buskill",
+		"key": "persistent_log",
+		"options": ["True","False"],
+		"options_human": ["True","False"],
+		"options_long": ["Log file will be not deleted after your system restarts","Log file will be deleted once you restart the computer"],
+		"confirmation": ["Please restart the app so the changes can be implimented","Please restart the app so the changes can be implimented"],
+		"options_icons": ["",""]
+	},
+	{
+		"type": "title",
 		"title": "Look & Feel"
 	},
 	{

--- a/src/packages/buskill/settings_buskill.json
+++ b/src/packages/buskill/settings_buskill.json
@@ -13,11 +13,7 @@
 		"options_icons": ["\ue1bf","\ue62a"]
 	},
 	{
-		"type": "title",
-		"title": "Buskill Complex Settings Option"
-	},
-	{
-		"icon": "",
+		"icon": "\ue873",
 		"type": "complex-options",
 		"title": "Persistent Logging",
 		"desc": "DO you want to store the log ?",
@@ -27,7 +23,7 @@
 		"options_human": ["True","False"],
 		"options_long": ["Log file will be not deleted after your system restarts","Log file will be deleted once you restart the computer"],
 		"confirmation": ["Please restart the app so the changes can be implimented","Please restart the app so the changes can be implimented"],
-		"options_icons": ["",""]
+		"options_icons": ["\ue161","\ue5cd"]
 	},
 	{
 		"type": "title",

--- a/src/packages/buskill/settings_buskill.json
+++ b/src/packages/buskill/settings_buskill.json
@@ -16,7 +16,7 @@
 		"icon": "\ue873",
 		"type": "complex-options",
 		"title": "Persistent Logging",
-		"desc": "DO you want to store the log ?",
+		"desc": "Do you want to store the log file persistently (keeping the data after your computer reboots)?",
 		"section": "buskill",
 		"key": "persistent_log",
 		"options": ["True","False"],


### PR DESCRIPTION
# Pytest logging

This solves the issue raised in #131.

## Problem

When BusKill is instantiated under pytest, `logger.root.handlers[0]` may be a `_LiveLoggingNullHandler`. Unlike a normal FileHandler, this object does not provide a baseFilename attribute, causing:

AttributeError: `_LiveLoggingNullHandler` object has no attribute `baseFilename`

The previous fix introduced in #121 prevented an IndexError when no handlers were present, but it did not handle logging handlers that lack a baseFilename attribute.

## Solution

Use getattr() when retrieving baseFilename and handle the case where no handlers are present. ( Solution given by @prashanth-kaki )

This prevents both:

IndexError when logger.root.handlers is empty. ( In the PR #121 )
AttributeError when the active logging handler does not provide baseFilename. ( Implemented in this PR ) 
## Testing

Reproduced on:

Parrot Security 6.4 (Debian 12 based OS)
Python 3.13.9
pytest 9.1.0

Verified that BusKill() can now be instantiated successfully under pytest without raising an exception :nerd_face: 
 