### PR TITLE
Fix LOG_FILE_PATH initialization under pytest

### DIFF
--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -227,7 +227,8 @@ class BusKill:
 
 		# BusKill class was always initialised after finding the log file path Therefore in the new setup we are initialising it before the log file path is found
 		# This will prevent it from out of index error 
-		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else None
+		handler = logger.root.handlers[0] if logger.root.handlers else None
+		self.LOG_FILE_PATH = getattr(handler, "baseFilename", None) if handler else None # Handle logging handlers without baseFilename 
 		# Default value as False, because if no one updates the config.ini file then reverting back to old file path
 		self.PERSISTENT_LOG = False
 		


### PR DESCRIPTION
# Pytest logging
This solves the issue raised in https://github.com/BusKill/buskill-app/issues/131.

## Problem
When BusKill is instantiated under pytest, `logger.root.handlers[0]` may be a `_LiveLoggingNullHandler`. Unlike a normal FileHandler, this object does not provide a baseFilename attribute, causing:

AttributeError: _LiveLoggingNullHandler object has no attribute baseFilename

The previous fix introduced in https://github.com/BusKill/buskill-app/pull/121 prevented an IndexError when no handlers were present, but it did not handle logging handlers that lack a baseFilename attribute.

## Solution
Use getattr() when retrieving baseFilename and handle the case where no handlers are present. ( Solution given by @prashanth-kaki )

This prevents both:

IndexError when logger.root.handlers is empty. ( In the PR #121 )
AttributeError when the active logging handler does not provide baseFilename. ( Implemented in this PR )

## Testing
Reproduced on:

Parrot Security 6.4 (Debian 12 based OS)
Python 3.13.9
pytest 9.1.0

Verified that BusKill() can now be instantiated successfully under pytest without raising an exception 🤓

A small error has happened so I am opening this new PR instead of #132 :disappointed: 