### PR TITLE
fix: guard LOG_FILE_PATH against handlers without baseFilename (fixes #131)

### DIFF
--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -224,7 +224,8 @@ class BusKill:
 		self.SIMULATE_HOTPLUG_REMOVAL = False
 
 		self.EXECUTED_AS_SCRIPT = None
-		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename
+		handler = logger.root.handlers[0] if logger.root.handlers else None
+		self.LOG_FILE_PATH = getattr(handler, 'baseFilename', None)
 		self.EXE_PATH = None
 		self.EXE_DIR = None
 		self.EXE_FILE = None


### PR DESCRIPTION
## Summary

- `BusKill.__init__` hard-coded `logger.root.handlers[0].baseFilename` on line 227
- pytest replaces the root handler with `_LiveLoggingNullHandler`, which has no `baseFilename` attribute, so every test that instantiates `BusKill()` crashed with `AttributeError`
- Fixed by using `getattr(handler, 'baseFilename', None)` and also guarding against an empty handlers list

## Changes

`src/packages/buskill/__init__.py` line 227:
```python
# before
self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename

# after
handler = logger.root.handlers[0] if logger.root.handlers else None
self.LOG_FILE_PATH = getattr(handler, 'baseFilename', None)
```

## Test plan

- [ ] Instantiate `BusKill()` inside a pytest test — no longer raises `AttributeError`
- [ ] Normal runtime behaviour unchanged: `LOG_FILE_PATH` still resolves to the log file path when a `FileHandler` is configured

Closes #131