### PR TITLE
fix: replace hardcoded developer git path with dynamic repo root (fixes #111)

### DIFF
--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -1992,9 +1992,14 @@ class BusKill:
 		# the only reason the SOURCE_DATE_EPOCH would be missing is if we're executing
 		# the python files directly (eg we're testing) and we can just get it from git
 		if BUSKILL_VERSION['SOURCE_DATE_EPOCH'] == '':
+			# derive the repo root dynamically: buskill/__init__.py lives at
+			# <repo>/src/packages/buskill/__init__.py, so go up 4 levels
+			repo_root = os.path.abspath(
+			 os.path.join( os.path.dirname(__file__), '..', '..', '..' )
+			)
 			result = subprocess.run( [
 			 'git',
-			 '--git-dir=/home/user/sandbox/buskill-app/.git',
+			 '-C', repo_root,
 			 'log',
 			 '-1',
 			 '--pretty=%ct'


### PR DESCRIPTION
## Summary

The upgrade flow contained a hardcoded path to the original developer's local machine:

```python
'--git-dir=/home/user/sandbox/buskill-app/.git'
```

This caused `fatal: not a git repository` on every system other than the developer's, crashing the upgrade flow whenever `SOURCE_DATE_EPOCH` was not set (i.e. in development / testing builds).

## Changes

Replace the hardcoded path with one derived dynamically from `__file__`:

```python
# before
result = subprocess.run( [
 'git',
 '--git-dir=/home/user/sandbox/buskill-app/.git',
 'log', '-1', '--pretty=%ct'
], capture_output = True )

# after
repo_root = os.path.abspath(
 os.path.join( os.path.dirname(__file__), '..', '..', '..' )
)
result = subprocess.run( [
 'git', '-C', repo_root,
 'log', '-1', '--pretty=%ct'
], capture_output = True )
```

`buskill/__init__.py` lives at `src/packages/buskill/__init__.py`, so 3 directories up is always the repo root. Using `git -C` rather than `--git-dir` means it works regardless of the current working directory.

## Test plan

- [ ] Run upgrade check in a development build (no `SOURCE_DATE_EPOCH`) — no longer crashes with `fatal: not a git repository`
- [ ] Verify `SOURCE_DATE_EPOCH` is correctly populated from `git log` output

Closes #111