### PR TITLE
Fixed the font update functionality for not yet created dialogs

### DIFF
--- a/src/buskill_gui.py
+++ b/src/buskill_gui.py
@@ -527,6 +527,16 @@ class DialogConfirmation(ModalView):
 		else:
 			self.b_continue.text = self.button
 
+		# Update fonts after the dialog has been fully built 
+		# Also adding a new debug message to see if it gets updated or not
+		Clock.schedule_once(
+			lambda dt: (
+				print(f"DEBUG: Updating fonts for dialog {self}"),
+				update_font_recursive(self)
+			),
+			0
+		)
+
 class CriticalError(BoxLayout):
 
 	msg = ObjectProperty(None)


### PR DESCRIPTION
## Problem
The `update_font_recursive()` function updates the font of widgets that already exist in the widget tree. However, DialogConfirmation instances are created lazily they are only instantiated when the user opens dialogs such as About, Check for Updates, etc.

Because these dialogs do not exist when update_font_recursive() is initially executed, their widgets are skipped and continue using the previous font. As a result, dialogs opened after changing the font do not reflect the newly selected font.
## Solution
To ensure newly created dialogs always use the current application font, a font update is triggered from the DialogConfirmation constructor.

The update is scheduled using `Clock.schedule_once(...)` instead of calling update_font_recursive() directly. This ensures the dialog has been fully constructed and all child widgets have been added before recursively updating their fonts. Calling the function immediately during construction would occur too early ( Did that and some weird things like partially font uodated dialogs and all was present ), before the widget tree is complete.

This change guarantees that every newly created dialog automatically adopts the currently configured font without requiring any additional updates elsewhere in the application.

---

This is a solution to the issue #138 but the issue of font listing not updating for some or the other reason is not popping up I wrote this solution for the About and Update session not for the Font list, but for some or the other reason I find it fixed when I run the program 