### PR TITLE
fix: tolerate log handlers without baseFilename (pytest compat)

### DIFF
--- a/src/packages/buskill/__init__.py
+++ b/src/packages/buskill/__init__.py
@@ -227,7 +227,7 @@ class BusKill:
 
 		# BusKill class was always initialised after finding the log file path Therefore in the new setup we are initialising it before the log file path is found
 		# This will prevent it from out of index error 
-		self.LOG_FILE_PATH = logger.root.handlers[0].baseFilename if logger.root.handlers else None
+		self.LOG_FILE_PATH = getattr( logger.root.handlers[0], 'baseFilename', None ) if logger.root.handlers else None
 		# Default value as False, because if no one updates the config.ini file then reverting back to old file path
 		self.PERSISTENT_LOG = False
 		


### PR DESCRIPTION
Closes #131

## Bug
BusKill.__init__ crashed under pytest with AttributeError: '_LiveLoggingNullHandler' object has no attribute 'baseFilename' at src/packages/buskill/__init__.py:227, because pytest replaces root handlers with its own (no baseFilename).

## Fix
One line on dev: getattr fallback so handlers without baseFilename yield None instead of crash. Dev already guarded empty handlers list but not missing attribute; this strengthens it. Normal FileHandler path unchanged (real path preserved).

Before: logger.root.handlers[0].baseFilename if handlers else None -> AttributeError under pytest
After: getattr(handlers[0], 'baseFilename', None) if handlers else None -> None under pytest, real path normally

## Tests
- Repro instantiating BusKill under pytest: FAILED before (exact AttributeError), passes after (LOG_FILE_PATH None)
- Edge: no handlers None, NullHandler None, StreamHandler None, FileHandler real path, mixed None no crash (5/5)
- py_compile clean (pre-existing SyntaxWarnings only)
- Note: LOG_FILE_PATH None only in test/embedded contexts; main.py always configures FileHandler so app unaffected. macOS root-child argv consumer noted.

## Files
- src/packages/buskill/__init__.py (1 line)